### PR TITLE
Fix: WARNING Using `cover.COVER_SCHEMA` is deprecated

### DIFF
--- a/components/hcpbridge/cover/__init__.py
+++ b/components/hcpbridge/cover/__init__.py
@@ -12,10 +12,12 @@ DEPENDENCIES = ['hcpbridge']
 HCPBridgeCover = hcpbridge_ns.class_("HCPBridgeCover", cover.Cover, cg.PollingComponent)
 
 CONFIG_SCHEMA = cv.All(
-  cover.COVER_SCHEMA.extend({
-    cv.GenerateID(): cv.declare_id(HCPBridgeCover),
-    cv.GenerateID(CONF_HCPBridge_ID): cv.use_id(HCPBridge),
-  }).extend(cv.polling_component_schema("500ms")),
+  cover.cover_schema(HCPBridgeCover)
+  .extend(
+      {
+        cv.GenerateID(CONF_HCPBridge_ID): cv.use_id(HCPBridge),
+      }
+  ).extend(cv.polling_component_schema("500ms")),
 )
 
 async def to_code(config):


### PR DESCRIPTION
This PR fixes the following warning:

```
WARNING Using `cover.COVER_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0. 
Please use `cover.cover_schema(...)` instead.
If you are seeing this, report an issue to the external_component author and ask them to update it. 
https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/. Component using this schema: hcpbridge
```

See https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/ for more information.